### PR TITLE
Add tint fallbacks

### DIFF
--- a/src/main/resources/assets/minecraft/items/acacia_leaves.json
+++ b/src/main/resources/assets/minecraft/items/acacia_leaves.json
@@ -5,7 +5,8 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "foliage"
+        "mode": "foliage",
+        "fallback": -12012264
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/axolotl_bucket.json
+++ b/src/main/resources/assets/minecraft/items/axolotl_bucket.json
@@ -5,7 +5,8 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "bucket"
+        "mode": "bucket",
+        "fallback": [0.22, 0.37, 0.8]
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/bush.json
+++ b/src/main/resources/assets/minecraft/items/bush.json
@@ -5,7 +5,12 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "grass"
+        "mode": "grass",
+        "fallback": {
+          "type": "minecraft:grass",
+          "downfall": 1,
+          "temperature": 0.5
+        }
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/cod_bucket.json
+++ b/src/main/resources/assets/minecraft/items/cod_bucket.json
@@ -5,7 +5,8 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "bucket"
+        "mode": "bucket",
+        "fallback": [0.22, 0.37, 0.8]
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/dark_oak_leaves.json
+++ b/src/main/resources/assets/minecraft/items/dark_oak_leaves.json
@@ -5,7 +5,8 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "foliage"
+        "mode": "foliage",
+        "fallback": -12012264
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/fern.json
+++ b/src/main/resources/assets/minecraft/items/fern.json
@@ -5,7 +5,12 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "grass"
+        "mode": "grass",
+        "fallback": {
+          "type": "minecraft:grass",
+          "downfall": 1,
+          "temperature": 0.5
+        }
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/grass_block.json
+++ b/src/main/resources/assets/minecraft/items/grass_block.json
@@ -5,7 +5,12 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "grass"
+        "mode": "grass",
+        "fallback": {
+          "type": "minecraft:grass",
+          "downfall": 1,
+          "temperature": 0.5
+        }
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/jungle_leaves.json
+++ b/src/main/resources/assets/minecraft/items/jungle_leaves.json
@@ -5,7 +5,8 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "foliage"
+        "mode": "foliage",
+        "fallback": -12012264
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/large_fern.json
+++ b/src/main/resources/assets/minecraft/items/large_fern.json
@@ -5,7 +5,12 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "grass"
+        "mode": "grass",
+        "fallback": {
+          "type": "minecraft:grass",
+          "downfall": 1,
+          "temperature": 0.5
+        }
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/leaf_litter.json
+++ b/src/main/resources/assets/minecraft/items/leaf_litter.json
@@ -5,7 +5,8 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "dry_foliage"
+        "mode": "dry_foliage",
+        "fallback": [0.65, 0.52, 0.32]
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/mangrove_leaves.json
+++ b/src/main/resources/assets/minecraft/items/mangrove_leaves.json
@@ -5,7 +5,8 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "foliage"
+        "mode": "foliage",
+        "fallback": -12012264
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/oak_leaves.json
+++ b/src/main/resources/assets/minecraft/items/oak_leaves.json
@@ -5,7 +5,8 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "foliage"
+        "mode": "foliage",
+        "fallback": -12012264
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/pink_petals.json
+++ b/src/main/resources/assets/minecraft/items/pink_petals.json
@@ -5,7 +5,12 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "grass"
+        "mode": "grass",
+        "fallback": {
+          "type": "minecraft:grass",
+          "downfall": 1,
+          "temperature": 0.5
+        }
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/pufferfish_bucket.json
+++ b/src/main/resources/assets/minecraft/items/pufferfish_bucket.json
@@ -5,7 +5,8 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "bucket"
+        "mode": "bucket",
+        "fallback": [0.22, 0.37, 0.8]
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/salmon_bucket.json
+++ b/src/main/resources/assets/minecraft/items/salmon_bucket.json
@@ -5,7 +5,8 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "bucket"
+        "mode": "bucket",
+        "fallback": [0.22, 0.37, 0.8]
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/short_grass.json
+++ b/src/main/resources/assets/minecraft/items/short_grass.json
@@ -5,7 +5,12 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "grass"
+        "mode": "grass",
+        "fallback": {
+          "type": "minecraft:grass",
+          "downfall": 1,
+          "temperature": 0.5
+        }
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/sugar_cane.json
+++ b/src/main/resources/assets/minecraft/items/sugar_cane.json
@@ -5,7 +5,8 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "sugar_cane"
+        "mode": "sugar_cane",
+        "fallback": 8372786
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/tadpole_bucket.json
+++ b/src/main/resources/assets/minecraft/items/tadpole_bucket.json
@@ -5,7 +5,8 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "bucket"
+        "mode": "bucket",
+        "fallback": [0.20, 0.43, 0.39]
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/tall_grass.json
+++ b/src/main/resources/assets/minecraft/items/tall_grass.json
@@ -5,7 +5,12 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "grass"
+        "mode": "grass",
+        "fallback": {
+          "type": "minecraft:grass",
+          "downfall": 1,
+          "temperature": 0.5
+        }
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/tropical_fish_bucket.json
+++ b/src/main/resources/assets/minecraft/items/tropical_fish_bucket.json
@@ -5,7 +5,8 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "bucket"
+        "mode": "bucket",
+        "fallback": [0.22, 0.37, 0.8]
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/vine.json
+++ b/src/main/resources/assets/minecraft/items/vine.json
@@ -5,7 +5,8 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "foliage"
+        "mode": "foliage",
+        "fallback": -12012264
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/water_bucket.json
+++ b/src/main/resources/assets/minecraft/items/water_bucket.json
@@ -5,7 +5,8 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "bucket"
+        "mode": "bucket",
+        "fallback": [0.22, 0.37, 0.8]
       }
     ]
   }

--- a/src/main/resources/assets/minecraft/items/wildflowers.json
+++ b/src/main/resources/assets/minecraft/items/wildflowers.json
@@ -5,7 +5,12 @@
     "tints": [
       {
         "type": "item_tints:biome",
-        "mode": "grass"
+        "mode": "grass",
+        "fallback": {
+          "type": "minecraft:grass",
+          "downfall": 1,
+          "temperature": 0.5
+        }
       }
     ]
   }


### PR DESCRIPTION
Fixes item tints being broken outside of world contexts, like on the superflat customization and statistic screens.